### PR TITLE
Allow keyboard interrupt during scheduler

### DIFF
--- a/fake_attendance/launch_zoom.py
+++ b/fake_attendance/launch_zoom.py
@@ -21,8 +21,9 @@ sys.path.append(os.getcwd())
 from fake_attendance.info import ZOOM_LINK
 from fake_attendance.settings import (
     AGREE_RECORDING_IMAGE,
+    ZOOM_AGREE_RECORDING_POPUP_CLASS,
     ZOOM_CLASSROOM_CLASS,
-    ZOOM_AGREE_RECORDING_POPUP_CLASS)
+    ZOOM_LAUNCHING_CHROME)
 from fake_attendance.helper import get_last_match
 # pylint: enable=wrong-import-position
 
@@ -66,9 +67,14 @@ class LaunchZoom:
         # driver init if Zoom shut down in middle
         if not self.driver:
             self.driver = self.initialize_selenium()
+
+        # launch Zoom link
         self.driver.get(ZOOM_LINK)
         self.driver.maximize_window()
         time.sleep(5)
+
+        # connect to automated Chrome browser
+        self.pywinauto_app.connect(title=ZOOM_LAUNCHING_CHROME).top_window().set_focus()
 
         # accept zoom launch message
         pyautogui.press('tab')

--- a/fake_attendance/launch_zoom.py
+++ b/fake_attendance/launch_zoom.py
@@ -74,6 +74,7 @@ class LaunchZoom:
         time.sleep(5)
 
         # connect to automated Chrome browser
+        # because recent Chrome does not allow bypassing this popup
         self.pywinauto_app.connect(title=ZOOM_LAUNCHING_CHROME).top_window().set_focus()
 
         # accept zoom launch message

--- a/fake_attendance/scheduler.py
+++ b/fake_attendance/scheduler.py
@@ -75,7 +75,6 @@ class MyScheduler:
             keyboard.wait('ctrl+c')
         except KeyboardInterrupt:
             print('키보드로 중단 요청')
-            pass
         self.sched.shutdown()
 
 

--- a/fake_attendance/scheduler.py
+++ b/fake_attendance/scheduler.py
@@ -6,9 +6,11 @@ import os
 import sys
 
 from apscheduler.events import EVENT_JOB_EXECUTED
-from apscheduler.schedulers.background import BlockingScheduler
+from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.combining import OrTrigger
+
+import keyboard
 
 sys.path.append(os.getcwd())
 
@@ -30,7 +32,7 @@ class MyScheduler:
         initialize
         time_sets = [{'hour': int, 'minute': int},...]
         '''
-        self.sched = BlockingScheduler(standalone=True)
+        self.sched = BackgroundScheduler()
         self.fake_check_in = FakeCheckIn()
         self.launch_zoom = LaunchZoom()
         self.quit_zoom = QuitZoom()
@@ -68,10 +70,14 @@ class MyScheduler:
         'run scheduler'
         print('스케줄러 실행')
         self.add_jobs()
+        self.sched.start()
         try:
-            self.sched.start()
+            keyboard.wait('ctrl+c')
         except KeyboardInterrupt:
-            print('interrupt')
+            print('키보드로 중단 요청')
+            pass
+        self.sched.shutdown()
+
 
 if __name__ == '__main__':
     MyScheduler().run()

--- a/fake_attendance/settings.py
+++ b/fake_attendance/settings.py
@@ -33,7 +33,7 @@ AGREE_RECORDING_IMAGE = get_file_path('agree_recording.png', 'images')
 # 10:00, 11:20, 13:00, 14:30, 15:20, 17:00 if I got them all
 DIFF_MINUTE = 5
 CHECK_IN_TIMES = [get_time_sets(*TIME_SET, DIFF_MINUTE) for TIME_SET in\
-                  [(10,0), (11,20), (13,0), (14,30), (15,20), (17,0)]]
+                  [(10,0), (11,20), (13,11), (14,30), (15,20), (17,0)]]
 CHECK_IN_TIMES = [TIME_SET for TIME_SETS in CHECK_IN_TIMES for TIME_SET in TIME_SETS]
 ZOOM_ON_HOUR = 13    # at hour 13
 ZOOM_ON_MINUTE = '0, 1, 2, 3, 4'  # at minutes 0,1,2,3,4

--- a/fake_attendance/settings.py
+++ b/fake_attendance/settings.py
@@ -44,6 +44,7 @@ ZOOM_QUIT_MINUTE = 0
 ZOOM_RESIZE_PARAMETERS_LIST = [i/10 for i in range(3,11)] # Change Zoom window size
 ZOOM_AGREE_RECORDING_POPUP_CLASS = 'ZoomShadowFrameClass'
 ZOOM_CLASSROOM_CLASS = 'ZPContentViewWndClass'
+ZOOM_LAUNCHING_CHROME = '회의 시작 - Zoom - Chrome'
 
 # Check-in props
 LOGIN_WITH_KAKAO_BUTTON = 'login-form__button-title.css-caslt6'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 apscheduler==3.10.1
+keyboard==0.13.5
 pyautogui==0.9.54
 pywinauto==0.6.8
 selenium==4.9.1


### PR DESCRIPTION
Also focuses on the automated Chrome browser that launches Zoom because it may not open on the foreground.
Also changes checking time at 1 PM to 1:11 (1:01, 1:06, 1:11, 1:16, 1:21) because Zoom isn't launched yet