### PR TITLE
Use if-else instead of try-except in finding windows

### DIFF
--- a/fake_attendance/download_ext.py
+++ b/fake_attendance/download_ext.py
@@ -18,7 +18,7 @@ import pyautogui
 sys.path.append(os.getcwd())
 
 # pylint: disable=wrong-import-position
-from fake_attendance.helper import get_last_match
+from fake_attendance.helper import get_last_match, print_with_time
 from fake_attendance.settings import (CONTINUE_IMAGE, GET_CRX_LINK,
                   SCREEN_QR_READER_SOURCE, SCREEN_QR_READER_WEBSTORE_LINK)
 # pylint: enable=wrong-import-position
@@ -72,28 +72,28 @@ class DownloadExtensionSource:
         # Recent Chrome does not allow bypassing 'harmful download', so use pyautogui.
         pos = get_last_match(self.image)
         if pos != (0,0,0,0):
-            print('다운로드 "계속" 버튼 확인')
+            print_with_time('다운로드 "계속" 버튼 확인')
             pyautogui.click(pos) # must be on the bottom
             time.sleep(5)
         else:
-            print('다운로드 "계속" 버튼 찾을 수 없음')
+            print_with_time('다운로드 "계속" 버튼 찾을 수 없음')
 
     def run(self):
         'Run the download'
-        print('다운로드 스크립트 실행')
+        print_with_time('다운로드 스크립트 실행')
         if self.check_source_exists():
-            print('이미 디렉터리 안에 확장자 소스 파일 있음')
+            print_with_time('이미 디렉터리 안에 확장자 소스 파일 있음')
             return
         options = self.create_selenium_options()
         driver = self.initialize_selenium(options)
         self.download(driver)
         driver.quit()
         if os.path.isfile(SCREEN_QR_READER_SOURCE):
-            print('다운로드한 확장자 소스 파일 확인 완료')
+            print_with_time('다운로드한 확장자 소스 파일 확인 완료')
         else:
-            print('다운로드된 파일 없음')
+            print_with_time('다운로드된 파일 없음')
             raise AssertionError
-        print('다운로드 스크립트 종료')
+        print_with_time('다운로드 스크립트 종료')
         return
 
 if __name__ == '__main__':

--- a/fake_attendance/helper.py
+++ b/fake_attendance/helper.py
@@ -35,3 +35,8 @@ def get_time_sets(hour, minute, diff_minute=5):
     input_time = datetime.now().replace(hour=hour, minute=minute)
     time_list = [input_time + timedelta(minutes=diff_minute*i) for i in range(-2, 3)]
     return [{'hour': time_set.hour, 'minute': time_set.minute} for time_set in time_list]
+
+def print_with_time(*args):
+    'print with time in %H:%M:%S format'
+    now = datetime.strftime(datetime.now(), '%H:%M:%S')
+    print(now, *args)

--- a/fake_attendance/launch_zoom.py
+++ b/fake_attendance/launch_zoom.py
@@ -57,9 +57,8 @@ class LaunchZoom:
             self.agree_recording()
             return True
         # if not visible
-        else:
-            print('줌 입장 안 함. 실행 필요')
-            return False
+        print('줌 입장 안 함. 실행 필요')
+        return False
 
     def initialize_selenium(self):
         'Initialize Selenium and return driver'
@@ -93,14 +92,14 @@ class LaunchZoom:
 
     def check_launch_result(self):
         'check the result'
-        # Zoom's App hwnd for conference.
+        # if Zoom classroom visible
         if win32gui.IsWindowVisible(self.hwnd_zoom_classroom):
             print('줌 회의 실행/발견 성공')
             return True
-        else:
-            print('줌 회의 실행/발견 실패')
-            self.launch_zoom()
-            return False
+        # if not
+        print('줌 회의 실행/발견 실패')
+        self.launch_zoom()
+        return False
 
     def agree_recording(self, trial=1):
         'agree recording'

--- a/fake_attendance/launch_zoom.py
+++ b/fake_attendance/launch_zoom.py
@@ -19,6 +19,7 @@ sys.path.append(os.getcwd())
 
 # pylint: disable=wrong-import-position
 from fake_attendance.info import ZOOM_LINK
+from fake_attendance.helper import print_with_time
 from fake_attendance.settings import (
     AGREE_RECORDING_IMAGE,
     ZOOM_AGREE_RECORDING_POPUP_CLASS,
@@ -52,12 +53,12 @@ class LaunchZoom:
         # if visible
         if win32gui.IsWindowVisible(self.hwnd_zoom_classroom):
             win32gui.SetForegroundWindow(self.hwnd_zoom_classroom)
-            print('이미 줌 회의 입장중')
+            print_with_time('이미 줌 회의 입장중')
             # agree recording if there is popup
             self.agree_recording()
             return True
         # if not visible
-        print('줌 입장 안 함. 실행 필요')
+        print_with_time('줌 입장 안 함. 실행 필요')
         return False
 
     def initialize_selenium(self):
@@ -94,10 +95,10 @@ class LaunchZoom:
         'check the result'
         # if Zoom classroom visible
         if win32gui.IsWindowVisible(self.hwnd_zoom_classroom):
-            print('줌 회의 실행/발견 성공')
+            print_with_time('줌 회의 실행/발견 성공')
             return True
         # if not
-        print('줌 회의 실행/발견 실패')
+        print_with_time('줌 회의 실행/발견 실패')
         self.launch_zoom()
         return False
 
@@ -112,13 +113,13 @@ class LaunchZoom:
             pos = get_last_match(self.image)
             # if agree button found
             if pos != (0,0,0,0):
-                print('줌 녹화 동의 버튼 확인')
+                print_with_time('줌 녹화 동의 버튼 확인')
                 pyautogui.click(pos)
                 time.sleep(2)
             # if not found
             else:
                 trial += 1
-                print(f'중 녹화 동의 창 중에서 동의 버튼 확인 못 함.\
+                print_with_time(f'중 녹화 동의 창 중에서 동의 버튼 확인 못 함.\
                     재시도 횟수: {trial}')
                 # try again
                 self.agree_recording(trial)
@@ -126,29 +127,29 @@ class LaunchZoom:
             pos = get_last_match(self.image)
             # if the agree button is found
             if pos != (0,0,0,0):
-                print(f'줌 녹화 동의 창 건재함. 재시도 횟수: {trial}')
+                print_with_time(f'줌 녹화 동의 창 건재함. 재시도 횟수: {trial}')
                 trial += 1
                 # try again
                 self.agree_recording(trial)
             # if it is not found
             else:
                 # successfully agreed
-                print('줌 녹화 동의 완료')
+                print_with_time('줌 녹화 동의 완료')
                 return
         # agree window not found
         else:
             time.sleep(5)
-            print(f'줌 녹화 동의 창 발견 실패, 재시도 횟수: {trial}')
+            print_with_time(f'줌 녹화 동의 창 발견 실패, 재시도 횟수: {trial}')
             trial += 1
             # try again
             if not self.check_launch_result():
-                print('줌 회의 중단됨')
+                print_with_time('줌 회의 중단됨')
                 return
             self.agree_recording(trial)
 
     def run(self):
         'Run the launch'
-        print('줌 실행 스크립트 시작')
+        print_with_time('줌 실행 스크립트 시작')
 
         # if zoom already running, return
         if self.connect():

--- a/fake_attendance/notify.py
+++ b/fake_attendance/notify.py
@@ -16,6 +16,7 @@ from socket import gaierror
 sys.path.append(os.getcwd())
 
 # pylint: disable=wrong-import-position
+from fake_attendance.helper import print_with_time
 from fake_attendance.info import (
     EMAIL_ADDRESS,
     EMAIL_PASSWORD,
@@ -54,10 +55,10 @@ class SendEmail:
         try:
             smtp = smtplib.SMTP(SMTP_HOST, SMTP_PORT)
         except gaierror:
-            print('SMTP 호스트 이름 확인 필요')
+            print_with_time('SMTP 호스트 이름 확인 필요')
             return
         except TimeoutError:
-            print('SMTP 포트 번호 확인 필요')
+            print_with_time('SMTP 포트 번호 확인 필요')
             return
 
         smtp.ehlo()
@@ -65,7 +66,7 @@ class SendEmail:
         try:
             smtp.login(EMAIL_ADDRESS, EMAIL_PASSWORD)
         except SMTPAuthenticationError:
-            print('이메일 로그인 정보 확인 필요')
+            print_with_time('이메일 로그인 정보 확인 필요')
             return
 
         self.write_body()
@@ -74,7 +75,7 @@ class SendEmail:
 
         smtp.sendmail(EMAIL_ADDRESS, EMAIL_ADDRESS, msg.as_string())
 
-        print('이메일 발송 성공')
+        print_with_time('이메일 발송 성공')
 
         smtp.quit()
 

--- a/fake_attendance/quit_zoom.py
+++ b/fake_attendance/quit_zoom.py
@@ -10,6 +10,7 @@ import win32gui
 sys.path.append(os.getcwd())
 
 # pylint: disable=wrong-import-position
+from fake_attendance.helper import print_with_time
 from fake_attendance.settings import ZOOM_CLASSROOM_CLASS
 # pylint: enable=wrong-import-position
 
@@ -26,13 +27,13 @@ class QuitZoom:
         if win32gui.IsWindowVisible(hwnd_zoom_class_classroom):
             self.pywinauto_app.connect(class_name=ZOOM_CLASSROOM_CLASS, found_index=0)\
                 .kill(soft=True)
-            print('Zoom 회의 입장 확인 후 종료함')
+            print_with_time('Zoom 회의 입장 확인 후 종료함')
         else:
-            print('Zoom 회의 입장 안 함')
+            print_with_time('Zoom 회의 입장 안 함')
 
     def run(self):
         'Run the launch'
-        print('줌 종료 스크립트 시작')
+        print_with_time('줌 종료 스크립트 시작')
         self.connect_and_kill()
 
 if __name__ == '__main__':

--- a/fake_attendance/quit_zoom.py
+++ b/fake_attendance/quit_zoom.py
@@ -5,7 +5,7 @@ Quit Zoom
 import os
 import sys
 import pywinauto
-from pywinauto.findwindows import ElementNotFoundError
+import win32gui
 
 sys.path.append(os.getcwd())
 
@@ -22,12 +22,12 @@ class QuitZoom:
 
     def connect_and_kill(self):
         'connect to Zoom conference and kill'
-        try:
-            pywinauto.findwindows.find_element(class_name=ZOOM_CLASSROOM_CLASS)
+        hwnd_zoom_class_classroom = win32gui.FindWindow(ZOOM_CLASSROOM_CLASS, None)
+        if win32gui.IsWindowVisible(hwnd_zoom_class_classroom):
             self.pywinauto_app.connect(class_name=ZOOM_CLASSROOM_CLASS, found_index=0)\
                 .kill(soft=True)
             print('Zoom 회의 입장 확인 후 종료함')
-        except ElementNotFoundError:
+        else:
             print('Zoom 회의 입장 안 함')
 
     def run(self):

--- a/fake_attendance/scheduler.py
+++ b/fake_attendance/scheduler.py
@@ -16,6 +16,7 @@ sys.path.append(os.getcwd())
 
 # pylint: disable=wrong-import-position
 from fake_attendance.fake_check_in import FakeCheckIn
+from fake_attendance.helper import print_with_time
 from fake_attendance.launch_zoom import LaunchZoom
 from fake_attendance.quit_zoom import QuitZoom
 from fake_attendance.settings import (
@@ -64,17 +65,17 @@ class MyScheduler:
     def print_next_time(self):
         'print next trigger for next QR check'
         next_time = self.sched.get_job('fake_check_in').next_run_time
-        print('다음 출석 스크립트 실행 시각:', next_time.strftime(('%H:%M')))
+        print_with_time('다음 출석 스크립트 실행 시각:', next_time.strftime(('%H:%M')))
 
     def run(self):
         'run scheduler'
-        print('스케줄러 실행')
+        print_with_time('스케줄러 실행')
         self.add_jobs()
         self.sched.start()
         try:
             keyboard.wait('ctrl+c')
         except KeyboardInterrupt:
-            print('키보드로 중단 요청')
+            print_with_time('키보드로 중단 요청')
         self.sched.shutdown()
 
 

--- a/fake_attendance/settings.py
+++ b/fake_attendance/settings.py
@@ -42,6 +42,7 @@ ZOOM_QUIT_HOUR = 12
 
 # Zoom props
 ZOOM_RESIZE_PARAMETERS_LIST = [i/10 for i in range(3,11)] # Change Zoom window size
+# 이 회의는 호스트 또는 참가자가 기록 중입니다
 ZOOM_AGREE_RECORDING_POPUP_CLASS = 'ZPRecordingConsentClass'
 ZOOM_CLASSROOM_CLASS = 'ZPContentViewWndClass'
 ZOOM_LAUNCHING_CHROME = '회의 시작 - Zoom - Chrome'


### PR DESCRIPTION
Before connecting to the window, uses `win32gui.IsWindowVisible` to check if the window is present.

I want to delete pywinauto completely, but there doesn't seem to be a way to replace its `kill(soft=True)` method with win32gui.

Also prints time along with any print messages

And checks if Screen QR Reader output is a real url.