### PR TITLE
Adds more launch and quit Zoom hours and Fixes `error: (0, 'SetForegroundWindow', 'No error message is available')`

### DIFF
--- a/fake_attendance/helper.py
+++ b/fake_attendance/helper.py
@@ -7,6 +7,8 @@ import os
 from datetime import datetime, timedelta
 
 import pyautogui
+from win32com.client import Dispatch
+import win32gui
 
 def get_file_path(filename, sub=None):
     'return full file path'
@@ -39,3 +41,11 @@ def print_with_time(*args):
     'print with time in %H:%M:%S format'
     now = datetime.strftime(datetime.now(), '%H:%M:%S')
     print(now, *args)
+
+def send_alt_key_and_set_foreground(hwnd):
+    '''
+    send alt key to shell before setting foreground with win32gui to workaround
+    error: (0, 'SetForegroundWindow', 'No error message is available')
+    '''
+    Dispatch('WScript.Shell').SendKeys('%')
+    win32gui.SetForegroundWindow(hwnd)

--- a/fake_attendance/launch_zoom.py
+++ b/fake_attendance/launch_zoom.py
@@ -18,7 +18,7 @@ sys.path.append(os.getcwd())
 
 # pylint: disable=wrong-import-position
 from fake_attendance.info import ZOOM_LINK
-from fake_attendance.helper import print_with_time
+from fake_attendance.helper import print_with_time, send_alt_key_and_set_foreground
 from fake_attendance.settings import (
     AGREE_RECORDING_IMAGE,
     ZOOM_AGREE_RECORDING_POPUP_CLASS,
@@ -52,7 +52,7 @@ class LaunchZoom:
         self.hwnd_zoom_classroom = win32gui.FindWindow(ZOOM_CLASSROOM_CLASS, None)
         # if visible
         if win32gui.IsWindowVisible(self.hwnd_zoom_classroom):
-            win32gui.SetForegroundWindow(self.hwnd_zoom_classroom)
+            send_alt_key_and_set_foreground(self.hwnd_zoom_classroom)
             print_with_time('이미 줌 회의 입장중')
             # agree recording if there is popup
             self.agree_recording()
@@ -81,7 +81,7 @@ class LaunchZoom:
         # connect to automated Chrome browser
         # because recent Chrome does not allow bypassing this popup
         self.hwnd_zoom_launching_chrome = win32gui.FindWindow(None, ZOOM_LAUNCHING_CHROME_TITLE)
-        win32gui.SetForegroundWindow(self.hwnd_zoom_launching_chrome)
+        send_alt_key_and_set_foreground(self.hwnd_zoom_launching_chrome)
 
         # accept zoom launch message
         keyboard.press_and_release('tab')
@@ -110,7 +110,7 @@ class LaunchZoom:
         if win32gui.IsWindowVisible(hwnd_zoom_popup):
             print_with_time(self.is_agreed)
             # focus on the agree popup
-            win32gui.SetForegroundWindow(hwnd_zoom_popup)
+            send_alt_key_and_set_foreground(hwnd_zoom_popup)
             # press tab 4 times and hit space to agree
             for _ in range(4):
                 keyboard.press_and_release('tab')

--- a/fake_attendance/quit_zoom.py
+++ b/fake_attendance/quit_zoom.py
@@ -17,15 +17,11 @@ from fake_attendance.settings import ZOOM_CLASSROOM_CLASS
 class QuitZoom:
     'A class for quitting Zoom'
 
-    def __init__(self):
-        'initialize'
-        self.pywinauto_app = pywinauto.Application()
-
-    def connect_and_kill(self):
+    def connect_and_kill(self, pywinauto_app):
         'connect to Zoom conference and kill'
         hwnd_zoom_class_classroom = win32gui.FindWindow(ZOOM_CLASSROOM_CLASS, None)
         if win32gui.IsWindowVisible(hwnd_zoom_class_classroom):
-            self.pywinauto_app.connect(class_name=ZOOM_CLASSROOM_CLASS, found_index=0)\
+            pywinauto_app.connect(class_name=ZOOM_CLASSROOM_CLASS, found_index=0)\
                 .kill(soft=True)
             print_with_time('Zoom 회의 입장 확인 후 종료함')
         else:
@@ -33,8 +29,9 @@ class QuitZoom:
 
     def run(self):
         'Run the launch'
+        pywinauto_app = pywinauto.Application()
         print_with_time('줌 종료 스크립트 시작')
-        self.connect_and_kill()
+        self.connect_and_kill(pywinauto_app)
 
 if __name__ == '__main__':
     QuitZoom().run()

--- a/fake_attendance/scheduler.py
+++ b/fake_attendance/scheduler.py
@@ -21,8 +21,8 @@ from fake_attendance.launch_zoom import LaunchZoom
 from fake_attendance.quit_zoom import QuitZoom
 from fake_attendance.settings import (
     CHECK_IN_TIMES,
-    ZOOM_ON_HOUR,
-    ZOOM_QUIT_HOUR)
+    ZOOM_ON_HOURS,
+    ZOOM_QUIT_HOURS)
 # pylint: enable=wrong-import-position
 
 class MyScheduler:
@@ -55,9 +55,9 @@ class MyScheduler:
         '''
         self.sched.add_job(self.fake_check_in.run, self.check_in_trigger, id='fake_check_in')
         self.sched.add_job(self.launch_zoom.run, 'cron',\
-                           hour=ZOOM_ON_HOUR, id='lauch_zoom')
+                           hour=ZOOM_ON_HOURS, id='lauch_zoom')
         self.sched.add_job(self.quit_zoom.run, 'cron',\
-                           hour=ZOOM_QUIT_HOUR, id='quit_zoom')
+                           hour=ZOOM_QUIT_HOURS, id='quit_zoom')
         self.sched.add_listener(
             callback = lambda event: self.print_next_time(),
             mask = EVENT_JOB_EXECUTED)

--- a/fake_attendance/settings.py
+++ b/fake_attendance/settings.py
@@ -37,8 +37,8 @@ DIFF_MINUTE = 5
 CHECK_IN_TIMES = [get_time_sets(*TIME_SET, DIFF_MINUTE) for TIME_SET in\
                   [(10,0), (11,20), (13,11), (14,30), (15,20), (17,0)]]
 CHECK_IN_TIMES = [TIME_SET for TIME_SETS in CHECK_IN_TIMES for TIME_SET in TIME_SETS]
-ZOOM_ON_HOUR = 13
-ZOOM_QUIT_HOUR = 12
+ZOOM_ON_HOURS = '9,13'
+ZOOM_QUIT_HOURS = '12,18'
 
 # Zoom props
 ZOOM_RESIZE_PARAMETERS_LIST = [i/10 for i in range(3,11)] # Change Zoom window size


### PR DESCRIPTION
Starts at 9 AM and quit at 6 PM.
Fixes the error `error: (0, 'SetForegroundWindow', 'No error message is available')` which is said to be a bug within win32gui when setting a window foreground, etc. The solution is to send a key which most users use `Alt` for before setting it foreground.

Closes https://github.com/yjmd2222/fake-attendance/issues/29