### PR TITLE
Improve printing keyboard interrupt message

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,9 +2,8 @@ name: Pylint
 
 on:
   push:
-    branches:
-      - '!stats'
-      - main
+    branches-ignore:
+      - stats
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ For testing QR scan scheduler, you can run `python test_scheduler.py YOUR-ARGUME
 - A text file that contains a 24-hour format time sets such as [test_times.txt](test_times.txt)
 - A json-like format such as `'[{"hour": int, "minute": int},...]'`
 - Leaving it blank to run scheduler at default times: See [settings.py](fake_attendance/settings.py)
-- For a single test to fire right now, run `python -m fake_attendance.fake_check_in`.
+- For a single test to fire right away, run `python -m fake_attendance.fake_check_in`.
 
 ## How it works and why
-[![Last updated](https://img.shields.io/badge/last_updated-2023--06--21-blue)](#)
+[![Last updated](https://img.shields.io/badge/Last_updated-2023--06--21-blue)](#)
 
 This module automates all check-ins for you-know-what: launch and quit Zoom at corresponding times and read the QR code in Zoom to complete the check-in form.
 This check is done throughout the day. See [settings.py](fake_attendance/settings.py) for the actual timings.

--- a/fake_attendance/fake_check_in.py
+++ b/fake_attendance/fake_check_in.py
@@ -159,13 +159,19 @@ class FakeCheckIn:
                 elif kwargs['how'] == 'submit':
                     driver.execute_script('arguments[0].click();', element)
                 else:
-                    raise AssertionError
+                    assert kwargs['how'] in ['click', 'input', 'get_iframe', 'submit'] == True
                 print_with_time(f'{kwargs["element"]} 찾기 성공. {sleep}초 후 다음 단계로 진행')
                 time.sleep(sleep)
                 return True
             except NoSuchElementException:
                 print_with_time(f'{kwargs["element"]} 찾기 실패. {sleep}초 후 재시도')
                 time.sleep(sleep)
+            except KeyError as e:
+                print_with_time(f'kwarg의 매개변수 알맞게 입력했는지 확인 필요. 조회 실패: {e}, 입력: {list(kwargs)}')
+                break
+            except AssertionError as e:
+                print_with_time(f'how kwarg의 인자값 알맞게 입력했는지 확인 필요. 입력: {kwargs["how"]}')
+                break
 
         print_with_time('재시도 전부 실패. 현 상태에서 이메일 발송')
         return False

--- a/fake_attendance/fake_check_in.py
+++ b/fake_attendance/fake_check_in.py
@@ -159,17 +159,17 @@ class FakeCheckIn:
                 elif kwargs['how'] == 'submit':
                     driver.execute_script('arguments[0].click();', element)
                 else:
-                    assert kwargs['how'] in ['click', 'input', 'get_iframe', 'submit'] == True
+                    assert kwargs['how'] in ['click', 'input', 'get_iframe', 'submit']
                 print_with_time(f'{kwargs["element"]} 찾기 성공. {sleep}초 후 다음 단계로 진행')
                 time.sleep(sleep)
                 return True
             except NoSuchElementException:
                 print_with_time(f'{kwargs["element"]} 찾기 실패. {sleep}초 후 재시도')
                 time.sleep(sleep)
-            except KeyError as e:
-                print_with_time(f'kwarg의 매개변수 알맞게 입력했는지 확인 필요. 조회 실패: {e}, 입력: {list(kwargs)}')
+            except KeyError as error:
+                print_with_time(f'kwarg의 매개변수 알맞게 입력했는지 확인 필요. 조회 실패: {error}, 입력: {list(kwargs)}')
                 break
-            except AssertionError as e:
+            except AssertionError:
                 print_with_time(f'how kwarg의 인자값 알맞게 입력했는지 확인 필요. 입력: {kwargs["how"]}')
                 break
 

--- a/fake_attendance/scheduler.py
+++ b/fake_attendance/scheduler.py
@@ -43,11 +43,6 @@ class MyScheduler:
             for TIME_SET in time_sets
         ])
 
-    def shutdown(self, event):
-        'testing interrupt'
-        if self.sched.running and event:
-            self.sched.shutdown(wait=False)
-
     def add_jobs(self):
         '''
         add 1. grab zoom link on screen
@@ -73,12 +68,11 @@ class MyScheduler:
         print_with_time('스케줄러 실행')
         self.add_jobs()
         self.sched.start()
-        try:
-            keyboard.wait('ctrl+c')
-        except KeyboardInterrupt:
-            print_with_time('키보드로 중단 요청')
-        self.sched.shutdown()
-
+        while True:
+            if keyboard.is_pressed('ctrl+c'):
+                print_with_time('키보드로 중단 요청')
+                break
+        self.sched.shutdown(wait=False)
 
 if __name__ == '__main__':
     MyScheduler().run()

--- a/fake_attendance/scheduler.py
+++ b/fake_attendance/scheduler.py
@@ -69,7 +69,7 @@ class MyScheduler:
         self.add_jobs()
         self.sched.start()
         while True:
-            if keyboard.is_pressed('ctrl+c'):
+            if keyboard.is_pressed('ctrl+alt+c'):
                 print_with_time('키보드로 중단 요청')
                 break
         self.sched.shutdown(wait=False)


### PR DESCRIPTION
The keyboard module receives `Ctrl` + `c` input with `keyboard.wait()`, but this is not handled by KeyboardInterrupt exception. So use `keyboard.is_pressed()` to check if pressed in condition.

Also change the interrupt sequence to `Ctrl` + `Alt` + `c` because copying with `Ctrl` + `c` may trigger the method.

Also enhanced code design with exception in Selenium search logic.

And trigger pylint with `branches-ignore: [stats]` instead of excluding with `!stats`